### PR TITLE
[BRIP-3] Difficulty adjustment algorithm

### DIFF
--- a/src/bench/block_assemble.cpp
+++ b/src/bench/block_assemble.cpp
@@ -25,12 +25,13 @@
 
 static std::shared_ptr<CBlock> PrepareBlock(const CScript& coinbase_scriptPubKey)
 {
-    auto block = std::make_shared<CBlock>(
-        BlockAssembler{Params()}
-            .CreateNewBlock(coinbase_scriptPubKey)
-            ->block);
+ 
+    CBlock pblock = BlockAssembler{Params()}.CreateNewBlock(coinbase_scriptPubKey)->block;
+    pblock.nTime = ::chainActive.Tip()->GetBlockTime() + Params().GetConsensus().nPowTargetSpacing;
+    int nBits = GetNextWorkRequired(chainActive.Tip(), &pblock, Params().GetConsensus());
+    auto block = std::make_shared<CBlock>(pblock);
 
-    block->nTime = ::chainActive.Tip()->GetMedianTimePast() + 1;
+    block->nBits = nBits;
     block->hashMerkleRoot = BlockMerkleRoot(*block);
 
     return block;

--- a/src/chain.h
+++ b/src/chain.h
@@ -16,17 +16,24 @@
 
 /**
  * Maximum amount of time that a block timestamp is allowed to exceed the
- * current network-adjusted time before the block will be accepted.
+ * current network-adjusted time before the block will be accepted.f
+ 
+ * Based on: https://github.com/zawy12/difficulty-algorithms/issues/3
+ * FTL = N*T/20 = 45 * 600 / 20
+ * Bitcoin original value: 2 * 60 * 60
  */
-static constexpr int64_t MAX_FUTURE_BLOCK_TIME = 2 * 60 * 60;
+static constexpr int64_t MAX_FUTURE_BLOCK_TIME = 45 * 600 / 20;
 
 /**
  * Timestamp window used as a grace period by code that compares external
  * timestamps (such as timestamps passed to RPCs, or wallet key creation times)
  * to block timestamps. This should be set at least as high as
  * MAX_FUTURE_BLOCK_TIME.
+ 
+ * Folloing the change in MAX_FUTURE_BLOCK_TIME maintaining the original value.
+ * Bitcoin original value: TIMESTAMP_WINDOW = MAX_FUTURE_BLOCK_TIME.
  */
-static constexpr int64_t TIMESTAMP_WINDOW = MAX_FUTURE_BLOCK_TIME;
+static constexpr int64_t TIMESTAMP_WINDOW = 2 * 60 * 60;
 
 /**
  * Maximum gap between node time and block time used

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -96,6 +96,10 @@ public:
         // By default assume that the signatures in ancestors of this block are valid.
         consensus.defaultAssumeValid = uint256S("0x0000000000000000000f1c54590ee18d15ec70e68c8cd4cfbadb1b4f11697eee"); //563378
 
+        //POW DDA LWMA Parameters
+        consensus.nLwmaAveragingWindow = 45; //TODO 30-60
+        consensus.nLwmaMinWeightedSolvetimesFactor = 10;
+
         /**
          * The message start string is designed to be unlikely to occur in normal data.
          * The characters are rarely used upper ASCII, not valid as UTF-8, and produce
@@ -213,6 +217,10 @@ public:
         // By default assume that the signatures in ancestors of this block are valid.
         consensus.defaultAssumeValid = uint256S("0x00");
 
+        //POW DDA LWMA Parameters
+        consensus.nLwmaAveragingWindow = 45; //TODO 30-60
+        consensus.nLwmaMinWeightedSolvetimesFactor = 10;
+
         pchMessageStart[0] = 0xb3;
         pchMessageStart[1] = 0xdb;
         pchMessageStart[2] = 0x95;
@@ -298,6 +306,10 @@ public:
 
         // By default assume that the signatures in ancestors of this block are valid.
         consensus.defaultAssumeValid = uint256S("0x00");
+
+        //POW DDA LWMA Parameters
+        consensus.nLwmaAveragingWindow = 45; //TODO 30-60
+        consensus.nLwmaMinWeightedSolvetimesFactor = 10;
 
         pchMessageStart[0] = 0xfa;
         pchMessageStart[1] = 0xbf;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -98,7 +98,6 @@ public:
 
         //POW DDA LWMA Parameters
         consensus.nLwmaAveragingWindow = 45; //TODO 30-60
-        consensus.nLwmaMinWeightedSolvetimesFactor = 10;
 
         /**
          * The message start string is designed to be unlikely to occur in normal data.
@@ -219,7 +218,6 @@ public:
 
         //POW DDA LWMA Parameters
         consensus.nLwmaAveragingWindow = 45; //TODO 30-60
-        consensus.nLwmaMinWeightedSolvetimesFactor = 10;
 
         pchMessageStart[0] = 0xb3;
         pchMessageStart[1] = 0xdb;
@@ -309,7 +307,6 @@ public:
 
         //POW DDA LWMA Parameters
         consensus.nLwmaAveragingWindow = 45; //TODO 30-60
-        consensus.nLwmaMinWeightedSolvetimesFactor = 10;
 
         pchMessageStart[0] = 0xfa;
         pchMessageStart[1] = 0xbf;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -75,6 +75,10 @@ struct Params {
     int64_t DifficultyAdjustmentInterval() const { return nPowTargetTimespan / nPowTargetSpacing; }
     uint256 nMinimumChainWork;
     uint256 defaultAssumeValid;
+    /** LWMA Difficulty Adjustment Algorithm Parameters */
+    int64_t nLwmaAveragingWindow;
+    int64_t nLwmaMinWeightedSolvetimesFactor;
+
 };
 } // namespace Consensus
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -77,7 +77,6 @@ struct Params {
     uint256 defaultAssumeValid;
     /** LWMA Difficulty Adjustment Algorithm Parameters */
     int64_t nLwmaAveragingWindow;
-    int64_t nLwmaMinWeightedSolvetimesFactor;
 
 };
 } // namespace Consensus

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -83,8 +83,7 @@ unsigned int LwmaCalculateNextWorkRequired(const CBlockIndex* pindexLast, const 
     const int64_t T = params.nPowTargetSpacing;
 
    // For T=600, 300, 150 use approximately N=60, 90, 120
-   // const int64_t N = params.nLwmaAveragingWindow;  
-    const int64_t N = 45;  
+    const int64_t N = params.nLwmaAveragingWindow;  
 
     // Define a k that will be used to get a proper average after weighting the solvetimes.
     const int64_t k = N * (N + 1) * T / 2; 
@@ -125,16 +124,6 @@ unsigned int LwmaCalculateNextWorkRequired(const CBlockIndex* pindexLast, const 
         arith_uint256 target;
         target.SetCompact(block->nBits);
         avgTarget += target / N / k; // Dividing by k here prevents an overflow below.
-    }
-
-   // Limit the adjustment step in case of a steep decline in the average solve times  
-   // Based on Bitcoin Gold LWMA algorithm)
-
-    //const int64_t minFactor = params.nLwmaMinWeightedSolvetimesFactor;
-    const int64_t minFactor = 10000000;
-
-    if (sumWeightedSolvetimes < k / minFactor) {
-        sumWeightedSolvetimes = k / minFactor;
     }
 
    // Desired equation in next line was nextTarget = avgTarget * sumWeightSolvetimes / k

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -14,28 +14,20 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
 {
     assert(pindexLast != nullptr);
     unsigned int nProofOfWorkLimit = UintToArith256(params.powLimit).GetCompact();
-
-    // Only change once per difficulty adjustment interval
-    if ((pindexLast->nHeight+1) % params.DifficultyAdjustmentInterval() != 0)
+    
+    if (params.fPowAllowMinDifficultyBlocks)
     {
-        if (params.fPowAllowMinDifficultyBlocks)
-        {
-            // Special difficulty rule for testnet:
-            // If the new block's timestamp is more than 2* 10 minutes
-            // then allow mining of a min-difficulty block.
-            if (pblock->GetBlockTime() > pindexLast->GetBlockTime() + params.nPowTargetSpacing*2)
-                return nProofOfWorkLimit;
-        }
-        return pindexLast->nBits;
+    // Special difficulty rule for testnet:
+    // If the new block's timestamp is more than 2* 10 minutes
+    // then allow mining of a min-difficulty block.
+    if (pblock->GetBlockTime() > pindexLast->GetBlockTime() + params.nPowTargetSpacing*2)
+        return nProofOfWorkLimit;
     }
 
-    // Go back by what we want to be 14 days worth of blocks
-    int nHeightFirst = pindexLast->nHeight - (params.DifficultyAdjustmentInterval()-1);
-    assert(nHeightFirst >= 0);
-    const CBlockIndex* pindexFirst = pindexLast->GetAncestor(nHeightFirst);
-    assert(pindexFirst);
-
-    return CalculateNextWorkRequired(pindexLast, pindexFirst->GetBlockTime(), params);
+    if (params.fPowNoRetargeting)
+        return pindexLast->nBits;
+        
+    return LwmaCalculateNextWorkRequired(pindexLast, params);
 }
 
 unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params& params)
@@ -81,3 +73,76 @@ bool CheckProofOfWork(uint256 hash, unsigned int nBits, const Consensus::Params&
 
     return true;
 }
+
+// LWMA-1 for BTC/Zcash clones
+// Algorithm by Zawy, a modification of WT-144 by Tom Harding
+// https://github.com/zawy12/difficulty-algorithms/issues/3#issuecomment-442129791
+
+unsigned int LwmaCalculateNextWorkRequired(const CBlockIndex* pindexLast, const Consensus::Params& params)
+{
+    const int64_t T = params.nPowTargetSpacing;
+
+   // For T=600, 300, 150 use approximately N=60, 90, 120
+   // const int64_t N = params.nLwmaAveragingWindow;  
+    const int64_t N = 45;  
+
+    // Define a k that will be used to get a proper average after weighting the solvetimes.
+    const int64_t k = N * (N + 1) * T / 2; 
+
+    const int64_t height = pindexLast->nHeight;
+    const arith_uint256 powLimit = UintToArith256(params.powLimit);
+    
+   // New coins should just give away first N blocks before using this algorithm.
+    if (height < N) { return powLimit.GetCompact(); }
+
+    arith_uint256 avgTarget, nextTarget;
+    int64_t thisTimestamp, previousTimestamp;
+    int64_t sumWeightedSolvetimes = 0, j = 0;
+
+    const CBlockIndex* blockPreviousTimestamp = pindexLast->GetAncestor(height - N);
+    previousTimestamp = blockPreviousTimestamp->GetBlockTime();
+
+    // Loop through N most recent blocks. 
+    for (int64_t i = height - N + 1; i <= height; i++) {
+        const CBlockIndex* block = pindexLast->GetAncestor(i);
+
+        // Prevent solvetimes from being negative in a safe way. It must be done like this. 
+        // In particular, do not attempt anything like  if(solvetime < 0) {solvetime=0;}
+        // The +1 ensures new coins do not calculate nextTarget = 0.
+        thisTimestamp = (block->GetBlockTime() > previousTimestamp) ? 
+                            block->GetBlockTime() : previousTimestamp + 1;
+
+       // A 6*T limit will prevent large drops in difficulty from long solvetimes.
+        int64_t solvetime = std::min(6 * T, thisTimestamp - previousTimestamp);
+
+       // The following is part of "preventing negative solvetimes". 
+        previousTimestamp = thisTimestamp;
+       
+       // Give linearly higher weight to more recent solvetimes.
+        j++;
+        sumWeightedSolvetimes += solvetime * j; 
+
+        arith_uint256 target;
+        target.SetCompact(block->nBits);
+        avgTarget += target / N / k; // Dividing by k here prevents an overflow below.
+    }
+
+   // Limit the adjustment step in case of a steep decline in the average solve times  
+   // Based on Bitcoin Gold LWMA algorithm)
+
+    //const int64_t minFactor = params.nLwmaMinWeightedSolvetimesFactor;
+    const int64_t minFactor = 10000000;
+
+    if (sumWeightedSolvetimes < k / minFactor) {
+        sumWeightedSolvetimes = k / minFactor;
+    }
+
+   // Desired equation in next line was nextTarget = avgTarget * sumWeightSolvetimes / k
+   // but 1/k was moved to line above to prevent overflow in new coins
+
+    nextTarget = avgTarget * sumWeightedSolvetimes; 
+
+    if (nextTarget > powLimit) { nextTarget = powLimit; }
+
+    return nextTarget.GetCompact();
+}   

--- a/src/pow.h
+++ b/src/pow.h
@@ -16,6 +16,7 @@ class uint256;
 
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params&);
 unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params&);
+unsigned int LwmaCalculateNextWorkRequired(const CBlockIndex* pindexLast, const Consensus::Params& params);
 
 /** Check whether a block hash satisfies the proof-of-work requirement specified by nBits */
 bool CheckProofOfWork(uint256 hash, unsigned int nBits, const Consensus::Params&);

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -9,20 +9,7 @@
 #include <util/system.h>
 #include <test/test_bitcoin.h>
 #include <boost/test/unit_test.hpp>
-#include <consensus/consensus.h>
-#include <consensus/merkle.h>
-#include <consensus/tx_verify.h>
-#include <consensus/validation.h>
-#include <validation.h>
-#include <miner.h>
-#include <policy/policy.h>
-#include <pubkey.h>
-#include <script/standard.h>
-#include <txmempool.h>
 #include <uint256.h>
-#include <util/strencodings.h>
-#include <memory>
-#include <stdio.h>
 
 
 BOOST_FIXTURE_TEST_SUITE(pow_tests, BasicTestingSetup)

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -57,7 +57,8 @@ std::shared_ptr<CBlock> Block(const uint256& prev_hash)
     auto ptemplate = BlockAssembler(Params()).CreateNewBlock(pubKey);
     auto pblock = std::make_shared<CBlock>(ptemplate->block);
     pblock->hashPrevBlock = prev_hash;
-    pblock->nTime = ++time;
+    time += Params().GetConsensus().nPowTargetSpacing;
+    pblock->nTime = time;
 
     CMutableTransaction txCoinbase(*pblock->vtx[0]);
     txCoinbase.vout.resize(1);

--- a/src/timedata.h
+++ b/src/timedata.h
@@ -10,7 +10,13 @@
 #include <stdint.h>
 #include <vector>
 
-static const int64_t DEFAULT_MAX_TIME_ADJUSTMENT = 70 * 60;
+static const int64_t DEFAULT_MAX_TIME_ADJUSTMENT = 675; 
+/* 
+Based on: https://github.com/zcash/zcash/issues/4021
+Following the reduction of MAX_FUTURE_BLOCK_TIME to 45 * 600 / 20 = 1350
+DEFAULT_MAX_TIME_ADJUSTMENT is set to MAX_FUTURE_BLOCK_TIME / 2
+(Bitcoin original value: 70 * 60)
+*/
 
 class CNetAddr;
 


### PR DESCRIPTION
Following the discussion in [[BRIP-3] Difficulty adjustment algorithm #17](https://github.com/bitcoinroyale/whitepaper/issues/17), the PR includes a proposal to replace Bitcoin's difficulty adjustment algorithm (recalculating difficulty every 2016 blocks) with LWMA.

LWMA, designed by @zawy12, provides a per block difficulty update based on weighted moving average with linear weights of the last N blocks. The proposal uses N=45. 
In the early stages of the project a choice of N=45 for the default T=600sec target time makes sense.

Along with the change in the algorithm which takes into consideration a smaller time window  for the difficulty adjustment, MAX_FUTURE_BLOCK_TIME is reduced in order to prevent timestamp attacks. MAX_FUTURE_BLOCK_TIME was set to N*T/20 as discussed in @zawy12 issues mentioned below.
to 22.5 min. DEFAULT_MAX_TIME_ADJUSTMENT is reduced accordingly to half the FTL time.

**Chainparams and Constants**
- **consensus.nLwmaAveragingWindow** (N) - the average window size in block = 45. 
- **MAX_FUTURE_BLOCK_TIME** = 45 * 600 / 20 = 1350 (instead of 2 * 60 * 60)
- **DEFAULT_MAX_TIME_ADJUSTMENT** = 675 (instead of 70 * 60) 

**Tests and Benchmarks**
- **src/test/pow_tests**: a uint test section for LWMA was added with basic testing.
- **src/test/validation_block_tests**: modified the test to generate blocks with timestamp delta of nPowTargetSpacing (10 min) instead of 1 sec. The original test assumes no update in the difficulty. 
- **src/bench/block_assemble**: modified the block creation to have time delta of nPowTargetSpacing and set nBits correctly based on the difficulty. (similarly to validation_block_tests the test had an assumption of no difficulty update)

Notes:
- All unit tests pass.
- The change should not impact functional where fPowNoRetargeting is set.
- **test/functional/feature_pruning.py**: flaky (also on master)
- **test/functional/mining_basic.py**: fails (also on master) on "get block template must be called with the segwit rule set", I see that the rule was removed from rpc/mining.cpp, the test should be adjusted accordingly.


**Links:**
[LWMA difficulty algorithm #3](https://github.com/zawy12/difficulty-algorithms/issues/3)
[LWMA's history #24](https://github.com/zawy12/difficulty-algorithms/issues/24)
[Selecting N based on coin experience and Target solvetime #14](https://github.com/zawy12/difficulty-algorithms/issues/14)